### PR TITLE
Update License header in copied classes

### DIFF
--- a/Procyon.Core/src/main/java/com/strobel/core/OS.java
+++ b/Procyon.Core/src/main/java/com/strobel/core/OS.java
@@ -1,16 +1,17 @@
 /**
- * JLibs: Common Utilities for Java
- * Copyright (C) 2009  Santhosh Kumar T <santhosh.tekuri@gmail.com>
+ * Copyright 2015 Santhosh Kumar Tekuri
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * The JLibs authors license this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.strobel.core;

--- a/Procyon.Core/src/main/java/com/strobel/io/Ansi.java
+++ b/Procyon.Core/src/main/java/com/strobel/io/Ansi.java
@@ -1,16 +1,17 @@
 /**
- * JLibs: Common Utilities for Java
- * Copyright (C) 2009  Santhosh Kumar T <santhosh.tekuri@gmail.com>
+ * Copyright 2015 Santhosh Kumar Tekuri
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * The JLibs authors license this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.strobel.io;


### PR DESCRIPTION
The original Author changed the license in 2015, so this change removes an actual LGPL code and replaces it with a much friendlier Apache 2 license
Note that the class is unmodified. This change just reflects the license change the original author did:
https://github.com/santhosh-tekuri/jlibs/commit/49538c418cf9472d65a1e36dafa0c5c4a5dbde7a