### PR TITLE
Fix the build for the fatJar plugin + jcommander upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ out/
 *.iml
 build/
 cache.txt
-gradlew.bat
-gradle/wrapper/gradle-wrapper.properties
-gradle/wrapper/gradle-wrapper.jar
-gradlew
+/.classpath
+/.project
+/.settings/

--- a/Procyon.CompilerTools/.gitignore
+++ b/Procyon.CompilerTools/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/bin/
+/.settings/

--- a/Procyon.Core/.gitignore
+++ b/Procyon.Core/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/bin/

--- a/Procyon.Decompiler/.gitignore
+++ b/Procyon.Decompiler/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/bin/

--- a/Procyon.Decompiler/build.gradle
+++ b/Procyon.Decompiler/build.gradle
@@ -22,7 +22,7 @@ fatJar {
 }
 
 dependencies {
-    compile 'com.beust:jcommander:1.30'
+    compileOnly 'com.beust:jcommander:1.30'
     compile project(':Procyon.Core')
     compile project(':Procyon.CompilerTools')
 }

--- a/Procyon.Decompiler/build.gradle
+++ b/Procyon.Decompiler/build.gradle
@@ -14,7 +14,7 @@ uploadArchives.enabled = false
 apply plugin: 'eu.appsatori.fatjar'
 
 fatJar {
-//    from rootProject.allprojects.collect({ it.sourceSets.main.allSource })
+    from rootProject.allprojects.collect({ it.sourceSets.main.allSource })
 
     manifest {
         attributes 'Title': archivesBaseName, 'Manifest-Version': '1.0', 'Version': version, 'Main-Class' : 'com.strobel.decompiler.DecompilerDriver'

--- a/Procyon.Decompiler/build.gradle
+++ b/Procyon.Decompiler/build.gradle
@@ -26,3 +26,7 @@ dependencies {
     compile project(':Procyon.Core')
     compile project(':Procyon.CompilerTools')
 }
+
+artifacts {
+    archives fatJar
+}

--- a/Procyon.Decompiler/build.gradle
+++ b/Procyon.Decompiler/build.gradle
@@ -22,7 +22,7 @@ fatJar {
 }
 
 dependencies {
-    compileOnly 'com.beust:jcommander:1.30'
+    compile 'com.beust:jcommander:1.81'
     compile project(':Procyon.Core')
     compile project(':Procyon.CompilerTools')
 }

--- a/Procyon.Decompiler/src/main/java/com/strobel/decompiler/CommandLineOptions.java
+++ b/Procyon.Decompiler/src/main/java/com/strobel/decompiler/CommandLineOptions.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class CommandLineOptions {
     @Parameter(description = "<type names or class/jar files>")
-    private final List<String> _inputs = new ArrayList<>();
+    private List<String> _inputs = new ArrayList<>();
 
     @Parameter(
         names = { "-?", "--help" },

--- a/Procyon.Decompiler/src/main/java/com/strobel/decompiler/DecompilerDriver.java
+++ b/Procyon.Decompiler/src/main/java/com/strobel/decompiler/DecompilerDriver.java
@@ -64,7 +64,7 @@ public class DecompilerDriver {
         final boolean decompileJar = !StringUtilities.isNullOrWhitespace(jarFile);
 
         if (options.getPrintVersion()) {
-            JCommander.getConsole().println(Procyon.version());
+            JCommander.newBuilder().build().getConsole().println(Procyon.version());
             if (options.getPrintUsage()) {
                 jCommander.usage();
             }

--- a/Procyon.Expressions/.gitignore
+++ b/Procyon.Expressions/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/bin/

--- a/Procyon.Reflection/.gitignore
+++ b/Procyon.Reflection/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/bin/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Oct 27 14:39:59 EDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I noticed that the fatJar was incompatible with gradle 4+ because they stopped supporting a feature it was using.

I downgraded to gradle 3.5.1. It depends if you prefer the benefits of a newer gradle or the fatJar plugin. Let me know.

Also noticed that with the old jcommander version, the gradle build was looking for a jcommander project inside my own repo as I tried to use procyon as a dependency with jitpack, so I upgraded to a newer version.
