### PR TITLE
Add GitHub Gradle workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+# Triggers the workflow on push or pull request events for any branch
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
Adds a GitHub workflow for building the project on every push and pull request for any branch.
Note that this might result in multiple workflow runs when you as maintainer push to a branch and then create a pull request, though I guess that might be acceptable.

⚠️ Currently the workflow downloads the Gradle wrapper every time because the distribution URL specifies a newer version than the once currently checked in with Git, see also #17.
This is not ideal, but does not prevent this workflow from working either.