### PR TITLE
added javadocJar and sourcesJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,11 +80,6 @@ subprojects {
         from 'build/docs/javadoc'
     }
 
-    task sourcesJar(type: Jar, dependsOn: classes) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
-    }
-
     tasks.withType(Test) {
         testLogging {
             // set options for log level LIFECYCLE
@@ -122,6 +117,14 @@ subprojects {
     }
 
     if (project.name == "Procyon.Decompiler") {
+
+	    task sourcesJar(type: Jar, dependsOn: classes) {
+	        classifier = 'sources'
+	        from sourceSets.main.allSource
+	        from project(':Procyon.Core').collect { it.sourceSets.main.allSource }
+	        from project(':Procyon.CompilerTools').collect { it.sourceSets.main.allSource }
+	    }
+
         artifacts {
             archives jar
             archives javadocJar
@@ -129,6 +132,11 @@ subprojects {
         }
     }
     else {
+	    task sourcesJar(type: Jar, dependsOn: classes) {
+	        classifier = 'sources'
+	        from sourceSets.main.allSource
+	    }
+
         javadoc {
             options.encoding = 'UTF-8'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ subprojects {
     if (project.name == "Procyon.Decompiler") {
         artifacts {
             archives jar
+            archives javadocJar
+            archives sourcesJar
         }
     }
     else {


### PR DESCRIPTION
I find it helpful to have source attachment when using the jar as a dependency. All the procyon-* jars come with sources and javadoc except procyon-decompiler. With this change procyon-decompiler will also come with sources and javadoc with jitpack https://jitpack.io/#mstrobel/procyon/v0.6.0. Build with sources and javadoc here : https://jitpack.io/com/github/nbauma109/procyon/sources-javadoc-9d951d78e1-1/build.log